### PR TITLE
Make json_schema usable in pipe

### DIFF
--- a/bin/json_schema
+++ b/bin/json_schema
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 
+
 # Copyright 2014-2019 Noah Sussman New Media, LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+# Set 'strict mode'; 'set -e' will make the whole script exit if a
+# command fails instead of continuing on the next line, 'set -u'
+# will treat references to unset variables as an error and exit
+# immediately.
+set -eu
+
 
 if test ! "$(command -v jq)"; then
     echo "ERROR: jq is not in your path!"

--- a/bin/json_schema
+++ b/bin/json_schema
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Copyright 2014-2019 Noah Sussman New Media, LLC
 
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ ! -x "$(which jq)" ]
-then
+if test ! "$(command -v jq)"; then
     echo "ERROR: jq is not in your path!"
     exit 1
 fi

--- a/bin/json_schema
+++ b/bin/json_schema
@@ -14,16 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -z "$1" ]
-then
-    echo "Usage: `basename $0` <path to JSON file>"
-    exit 1
-elif [ ! -f "$1" ]
-then
-    echo "Usage: $(basename $0) <JSON file>"
-    echo "ERROR: Not a file: $1"
-    exit 1
-elif [ ! -x "$(which jq)" ]
+if [ ! -x "$(which jq)" ]
 then
     echo "ERROR: jq is not in your path!"
     exit 1
@@ -40,6 +31,6 @@ jq --raw-output \
               end)
         | join("")
         | "." + .' \
-    "$1" \
+        "$@" \
     | sort \
     | uniq -c


### PR DESCRIPTION
This pull request makes it possible to run json_schema in a pipe, e.g.:

```
aws cloudformation list-stacks | json_schema
      1 .["StackSummaries"]
     20 .["StackSummaries"][]
     20 .["StackSummaries"][]["CreationTime"]
     20 .["StackSummaries"][]["DeletionTime"]
     20 .["StackSummaries"][]["DriftInformation"]
     20 .["StackSummaries"][]["DriftInformation"]["StackDriftStatus"]
     20 .["StackSummaries"][]["StackId"]
     20 .["StackSummaries"][]["StackName"]
     20 .["StackSummaries"][]["StackStatus"]
     18 .["StackSummaries"][]["TemplateDescription"]
```

I also took the liberty to making the shell script more portable by removing the use of `which` and making the script use `sh` instead of `bash`.